### PR TITLE
filter missing packages

### DIFF
--- a/bin/user-installed-packages
+++ b/bin/user-installed-packages
@@ -118,8 +118,8 @@ uip_load() {
 			UIP_NOT_AVAILABLE="$UIP_NOT_AVAILABLE $i"
 		fi
 	done
-	echo "these packages are not available" |tee $HOME/UIP_NOT_AVAILABLE.txt 
-	echo "$UIP_NOT_AVAILABLE" |tee $HOME/UIP_NOT_AVAILABLE.txt
+	echo "$(gettext 'these packages are not available')" |tee $HOME/UIP_NOT_AVAILABLE.txt 
+	echo "$UIP_NOT_AVAILABLE" |tee -a $HOME/UIP_NOT_AVAILABLE.txt
 		
  	HOLDMESSAGE="$(gettext 'Press Enter to exit')"
 	

--- a/bin/user-installed-packages
+++ b/bin/user-installed-packages
@@ -110,9 +110,17 @@ uip_load() {
 
 	fi
 
-
- 	UIPINSTALL=$(echo "${UIPINSTALL[@]}" | sed -e 's/TRUE //g')
-	UIPINSTALL_AVAILABLE=$(apt-cache -q madison $(echo $UIPINSTALL) | awk '{print $1}')
+ 	UIPINSTALL_LIST=$(echo "${UIPINSTALL[@]}" | sed -e 's/TRUE //g')
+	UIPINSTALL_AVAILABLE=$(apt-cache -q madison $(echo ${UIPINSTALL_LIST}) | awk '{print $1}')
+	local UIP_NOT_AVAILABLE
+	for i in $UIPINSTALL_LIST; do
+		if ! echo ${UIPINSTALL_AVAILABLE} | grep -q -w "$i"; then
+			UIP_NOT_AVAILABLE="$UIP_NOT_AVAILABLE $i"
+		fi
+	done
+	echo "these packages are not available" |tee $HOME/UIP_NOT_AVAILABLE.txt 
+	echo "$UIP_NOT_AVAILABLE" |tee $HOME/UIP_NOT_AVAILABLE.txt
+		
  	HOLDMESSAGE="$(gettext 'Press Enter to exit')"
 	
 	#Install packages in separate terminal


### PR DESCRIPTION
this works on bullseye.  less certain on bookworm.  I have a problem but it might be my computer setup.  

for now the list of unavailable packages is spit into a file in the home folder.  that can go into a savable dialog or whatever, its just a variable now.